### PR TITLE
move `overwriteProtocol` and `defaultPhoneRegion` to services.nextcloud.settings

### DIFF
--- a/nextcloud.nix
+++ b/nextcloud.nix
@@ -46,9 +46,11 @@
           sha256 = "sha256-8XyOslMmzxmX2QsVzYzIJKNw6rVWJ7uDhU1jaKJ0Q8k=";
         };
       };
-      config = {
+      settings = {
         overwriteProtocol = "https";
-        defaultPhoneRegion = "US";
+        default_phone_region = "US";
+      };
+      config = {
         dbtype = "pgsql";
         adminuser = "admin";
         adminpassFile = "/REPLACE/WITH/YOUR/PATH";


### PR DESCRIPTION


this fixes how NixOS 24.05 gives trace warnings:

```
trace: warning: The option `services.nextcloud.config.overwriteProtocol' defined in `/etc/nixos/nixcloud.nix' has been renamed to `services.nextcloud.settings.overwriteprotocol'.
trace: warning: The option `services.nextcloud.config.defaultPhoneRegion' defined in `/etc/nixos/nixcloud.nix' has been renamed to `services.nextcloud.settings.default_phone_region'.
```