### PR TITLE
added pihole nix module

### DIFF
--- a/pihole.nix
+++ b/pihole.nix
@@ -1,0 +1,47 @@
+{
+  virtualisation = {
+    containers.enable = true;
+
+    podman = {
+      enable = true;
+      dockerCompat = true;
+      defaultNetwork.settings.dns_enabled = true;
+      autoPrune = {
+        enable = true;
+        dates = "weekly";
+      };
+    };
+
+    # Run pihole as a podman container, but we can manage it with systemd.
+    oci-containers = {
+      backend = "podman";
+      containers.pihole = {
+        image = "pihole/pihole:latest";
+        environment = {
+          TZ = "America/New_York";
+          WEBPASSWORD = "CHANGEME";
+          FTLCONF_LOCAL_IPV4 = "192.168.1.2";
+          INTERFACE = "eno1";
+        };
+        autoStart = true;
+        ports = [
+          "53:53/udp"
+          "53:53/tcp"
+          "80:80/tcp"
+        ];
+        volumes = [
+          "/opt/pihole/etc:/etc/pihole"
+          "/opt/pihole/etc-dnsmasq.d:/etc/dnsmasq.d"
+        ];
+        extraOptions = [ "--network=host" ];
+      };
+    };
+  };
+
+  # Open up the host's firewall for access to pihole.
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 53 80 ];
+    allowedUDPPorts = [ 53 ];
+  };
+}


### PR DESCRIPTION
Hello gents!

After over a year of listening to the show, I finally gave in and started learning nix. Let's just say I now run NixOS on nearly every single machine in my house, and I even use it at work to create reproducible builds for employee devices. It has been a wonderful journey so far, and I can't help but get the same feeling I had when I first started learning about Linux. So thank you!

Recently, I wanted to start 'nixifying' some of my docker-compose setup. I've created a simple module for spinning up a podman container running pihole as a systemd service, so that way I can just stick it on any NixOS machine and easily make it my DNS server. Given that a nixconfig repository was created for helpful nix configs, I thought I'd share it with the community in case anyone else finds it useful. 

Thanks for an awesome show. Cheers!